### PR TITLE
add option to suppress rendering of binding between double pages

### DIFF
--- a/src/main/java/net/sf/mcf2pdf/Main.java
+++ b/src/main/java/net/sf/mcf2pdf/Main.java
@@ -48,6 +48,7 @@ public class Main {
 		options.addOption("w", true, "Location for temporary images generated during conversion.");
 		options.addOption("r", true, "Sets the resolution to use for page rendering, in DPI. Default is 150.");
 		options.addOption("n", true, "Sets the page number to render up to. Default renders all pages.");
+		options.addOption("b", false, "Prevents rendering of binding between double pages.");
 		options.addOption("x", false, "Generates only XSL-FO content instead of PDF content.");
 		options.addOption("q", false, "Quiet mode - only errors are logged.");
 		options.addOption("d", false, "Enables debugging logging output.");
@@ -141,6 +142,11 @@ public class Main {
 				printUsage(options, new ParseException("Parameter for option -n must be an integer >= 0."));
 			}
 		}
+		
+		boolean binding = true;
+        if (cl.hasOption("b")) {
+        	binding = false;
+        }
 
 		OutputStream finalOut;
 		if (cl.getArgs()[1].equals("-"))
@@ -179,7 +185,7 @@ public class Main {
 
 		try {
 			new Mcf2FoConverter(installDir, tempDir, tempImages).convert(
-					mcfFile, xslFoOut, dpi, maxPageNo);
+					mcfFile, xslFoOut, dpi, binding, maxPageNo);
 			xslFoOut.flush();
 
 			if (!cl.hasOption("x")) {

--- a/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
+++ b/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
@@ -148,7 +148,7 @@ public class Mcf2FoConverter {
 	 * @throws SAXException If any XML related problem occurs, e.g. the input file
 	 * has an invalid format.
 	 */
-	public void convert(File mcfFile, OutputStream xslFoOut, int dpi, int maxPageNo) throws IOException, SAXException {
+	public void convert(File mcfFile, OutputStream xslFoOut, int dpi, boolean binding, int maxPageNo) throws IOException, SAXException {
 		// build MCF DOM
 		log.debug("Reading MCF file");
 		McfFotobook book = new FotobookBuilder().readFotobook(mcfFile);
@@ -236,7 +236,7 @@ public class Mcf2FoConverter {
 			log.info("Rendering pages " + i + "+" + (i+1) + "...");
 			processDoublePage(normalPages.get(i),
 					i + 1 < normalPages.size() ? normalPages.get(i + 1) : null,
-					imageDir, true);
+					imageDir, binding);
 			currentPage.addToDocumentBuilder(docBuilder);
 			if (i < normalPages.size() - 2) {
 				docBuilder.newPage();


### PR DESCRIPTION
I have added a command line option _b_ that allows for suppressing the rendering of binding between double pages, which is convenient for panoramic images spanning two pages. 