### PR TITLE
Fixed spine, other improvements

### DIFF
--- a/src/main/java/net/sf/mcf2pdf/Main.java
+++ b/src/main/java/net/sf/mcf2pdf/Main.java
@@ -24,7 +24,6 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 
-import net.sf.mcf2pdf.mcfelements.util.ImageUtil;
 import net.sf.mcf2pdf.mcfelements.util.PdfUtil;
 
 

--- a/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
+++ b/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
@@ -250,7 +250,6 @@ public class Mcf2FoConverter {
 					imageDir, binding);
 			currentPage.addToDocumentBuilder(docBuilder);
 			if (i < normalPages.size() - 2) {
-				docBuilder.newPage();
 				currentPage = new BitmapPageBuilder(pageWidthPX, pageHeightPX, context, tempImageDir);
 			}
 		}

--- a/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
+++ b/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
@@ -175,17 +175,28 @@ public class Mcf2FoConverter {
 		// create XSL-FO document
 		XslFoDocumentBuilder docBuilder = new XslFoDocumentBuilder();
 
-		float pageWidth = albumType.getUsableWidth() / 10.0f * 2;
-		float pageHeight = albumType.getUsableHeight() / 10.0f;
-
-		// set page master
-		docBuilder.addPageMaster("default", pageWidth, pageHeight);
-
-		// create master for cover
-		float coverPageWidth = pageWidth + (albumType.getCoverExtraHorizontal() * 2 + albumType.getSpineWidth(book.getNormalPages())) / 10.0f;
-		float coverPageHeight = pageHeight + albumType.getCoverExtraVertical() / 10.0f;
-
-		docBuilder.addPageMaster("cover", coverPageWidth, coverPageHeight);
+		// setting page widths for master pages
+		int coverPageWidthPX = -1;
+		int coverPageHeightPX = -1;
+		int pageWidthPX = -1;
+		int pageHeightPX = -1;
+		
+		for (McfPage p : book.getPages()) {
+			if (McfPage.FULLCOVER.matcher(p.getType()).matches() && coverPageWidthPX == -1 && coverPageHeightPX == -1) {
+				coverPageWidthPX = context.toPixel(p.getBundlesize().getWidth() / 10.0f);
+				coverPageHeightPX = context.toPixel(p.getBundlesize().getHeight() / 10.0f);
+			} else if (McfPage.CONTENT.matcher(p.getType()).matches()&& pageWidthPX == -1 && pageHeightPX == -1 ) {
+				pageWidthPX = context.toPixel(p.getBundlesize().getWidth() / 10.0f);
+				pageHeightPX = context.toPixel(p.getBundlesize().getHeight() / 10.0f);
+			}
+			if (coverPageWidthPX != -1 && coverPageHeightPX != -1 && pageWidthPX != -1 && pageHeightPX != -1) {
+				break;
+			}
+		}
+		
+		// setting master pages
+		docBuilder.addPageMaster("cover", coverPageWidthPX, coverPageHeightPX);
+		docBuilder.addPageMaster("default", pageWidthPX, pageHeightPX);
 
 		// prepare temporary folder
 		log.debug("Preparing temporary working directory");
@@ -205,7 +216,7 @@ public class Mcf2FoConverter {
 
 		if (leftCover != null) {
 			log.info("Rendering cover...");
-			currentPage = new BitmapPageBuilder(coverPageWidth, coverPageHeight, context, tempImageDir);
+			currentPage = new BitmapPageBuilder(coverPageWidthPX, coverPageHeightPX, context, tempImageDir);
 			processDoublePage(leftCover, rightCover, imageDir, false);
 			docBuilder.startFlow("cover");
 			currentPage.addToDocumentBuilder(docBuilder);
@@ -230,7 +241,7 @@ public class Mcf2FoConverter {
 		// now, process pages as a pair
 		docBuilder.startFlow("default");
 		log.debug("Starting rendering of " + normalPages.size() + " pages");
-		currentPage = new BitmapPageBuilder(pageWidth, pageHeight, context, tempImageDir);
+		currentPage = new BitmapPageBuilder(pageWidthPX, pageHeightPX, context, tempImageDir);
 
 		for (int i = 0; i < normalPages.size(); i += 2) {
 			log.info("Rendering pages " + i + "+" + (i+1) + "...");
@@ -240,7 +251,7 @@ public class Mcf2FoConverter {
 			currentPage.addToDocumentBuilder(docBuilder);
 			if (i < normalPages.size() - 2) {
 				docBuilder.newPage();
-				currentPage = new BitmapPageBuilder(pageWidth, pageHeight, context, tempImageDir);
+				currentPage = new BitmapPageBuilder(pageWidthPX, pageHeightPX, context, tempImageDir);
 			}
 		}
 
@@ -253,7 +264,7 @@ public class Mcf2FoConverter {
 
 	private void processDoublePage(McfPage leftPage, McfPage rightPage, File imageDir,
 			boolean addBinding) throws IOException {
-		// handle packgrounds
+		// handle backgrounds
 		PageBackground bg = new PageBackground(
 				leftPage == null ? Collections.<McfBackground>emptyList() : leftPage.getBackgrounds(),
 				rightPage == null ? Collections.<McfBackground>emptyList() : rightPage.getBackgrounds());
@@ -282,9 +293,7 @@ public class Mcf2FoConverter {
 		}
 
 		if (addBinding) {
-			currentPage.addDrawable(new PageBinding(resources.getBinding(),
-					(albumType.getUsableWidth() + albumType.getBleedMargin()) / 10.0f * 2,
-					(albumType.getUsableHeight() + albumType.getBleedMargin() * 2) / 10.0f));
+			currentPage.addDrawable(new PageBinding(resources.getBinding()));
 		}
 	}
 

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/McfBundlesize.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/McfBundlesize.java
@@ -1,0 +1,11 @@
+package net.sf.mcf2pdf.mcfelements;
+
+public interface McfBundlesize {
+	
+	public McfPage getPage();
+	
+	public int getHeight();
+	
+	public int getWidth();
+	
+}

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/McfPage.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/McfPage.java
@@ -20,6 +20,8 @@ public interface McfPage {
 	public final static Pattern SPINE = Pattern.compile("SPINE|spine");
 
 	public McfFotobook getFotobook();
+	
+	public McfBundlesize getBundlesize();
 
 	public List<? extends McfArea> getAreas();
 

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/DigesterConfiguratorImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/DigesterConfiguratorImpl.java
@@ -28,6 +28,7 @@ import net.sf.mcf2pdf.mcfelements.DigesterConfigurator;
 import net.sf.mcf2pdf.mcfelements.McfArea;
 import net.sf.mcf2pdf.mcfelements.McfBackground;
 import net.sf.mcf2pdf.mcfelements.McfBorder;
+import net.sf.mcf2pdf.mcfelements.McfBundlesize;
 import net.sf.mcf2pdf.mcfelements.McfClipart;
 import net.sf.mcf2pdf.mcfelements.McfFotobook;
 import net.sf.mcf2pdf.mcfelements.McfImage;
@@ -100,6 +101,12 @@ public class DigesterConfiguratorImpl implements DigesterConfigurator {
 		digester.addSetTop("fotobook/page", "setFotobook");
 		DigesterUtil.addSetProperties(digester, "fotobook/page", getSpecialPageAttributes());
 		digester.addSetNext("fotobook/page", "addPage", McfPage.class.getName());
+		
+		// bundlesize element
+		digester.addObjectCreate("fotobook/page/bundlesize", getBundlesizeClass());
+		digester.addSetTop("fotobook/page/bundlesize", "setPage");
+		digester.addSetProperties("fotobook/page/bundlesize");
+		digester.addSetNext("fotobook/page/bundlesize", "addBundlesize", McfBundlesize.class.getName());
 
 		// background element
 		digester.addObjectCreate("fotobook/page/background", getBackgroundClass());
@@ -227,6 +234,10 @@ public class DigesterConfiguratorImpl implements DigesterConfigurator {
 		List<String[]> result = new Vector<String[]>();
 		result.add(new String[] { "pagenr", "pageNr" });
 		return result;
+	}
+	
+	protected Class<? extends McfBundlesize> getBundlesizeClass() {
+		return McfBundlesizeImpl.class;
 	}
 
 	protected Class<? extends McfBackground> getBackgroundClass() {

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/DigesterConfiguratorImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/DigesterConfiguratorImpl.java
@@ -106,7 +106,7 @@ public class DigesterConfiguratorImpl implements DigesterConfigurator {
 		digester.addObjectCreate("fotobook/page/bundlesize", getBundlesizeClass());
 		digester.addSetTop("fotobook/page/bundlesize", "setPage");
 		digester.addSetProperties("fotobook/page/bundlesize");
-		digester.addSetNext("fotobook/page/bundlesize", "addBundlesize", McfBundlesize.class.getName());
+		digester.addSetNext("fotobook/page/bundlesize", "setBundlesize", McfBundlesize.class.getName());
 
 		// background element
 		digester.addObjectCreate("fotobook/page/background", getBackgroundClass());

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfBundlesizeImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfBundlesizeImpl.java
@@ -1,0 +1,39 @@
+package net.sf.mcf2pdf.mcfelements.impl;
+
+import net.sf.mcf2pdf.mcfelements.McfBundlesize;
+import net.sf.mcf2pdf.mcfelements.McfPage;
+
+public class McfBundlesizeImpl implements McfBundlesize {
+
+	private McfPage page;
+	private int height;
+	private int width;
+	
+	@Override
+	public McfPage getPage() {
+		return page;
+	}
+	
+	public void setPage(McfPage page) {
+		this.page = page;
+	}
+
+	@Override
+	public int getHeight() {
+		return height;
+	}
+	
+	public void setHeight(int height) {
+		this.height = height;
+	}
+
+	@Override
+	public int getWidth() {
+		return width;
+	}
+	
+	public void setWidth(int width) {
+		this.width = width;
+	}
+
+}

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
@@ -69,7 +69,7 @@ public class McfPageImpl implements McfPage {
 		return bundlesize;
 	}
 	
-	public void setBundlesize(McfBundlesize bundlesize) {
+	public void addBundlesize(McfBundlesize bundlesize) {
 		this.bundlesize = bundlesize;
 	}
 

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
@@ -69,7 +69,7 @@ public class McfPageImpl implements McfPage {
 		return bundlesize;
 	}
 	
-	public void addBundlesize(McfBundlesize bundlesize) {
+	public void setBundlesize(McfBundlesize bundlesize) {
 		this.bundlesize = bundlesize;
 	}
 

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/impl/McfPageImpl.java
@@ -14,6 +14,8 @@ public class McfPageImpl implements McfPage {
 	
 	private McfFotobook fotobook;
 	
+	private McfBundlesize bundlesize;
+	
 	private int pageNr;
 	
 	private String type;
@@ -60,6 +62,15 @@ public class McfPageImpl implements McfPage {
 
 	public void setType(String type) {
 		this.type = type;
+	}
+
+	@Override
+	public McfBundlesize getBundlesize() {
+		return bundlesize;
+	}
+	
+	public void setBundlesize(McfBundlesize bundlesize) {
+		this.bundlesize = bundlesize;
 	}
 
 }

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/util/XslFoDocumentBuilder.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/util/XslFoDocumentBuilder.java
@@ -36,12 +36,12 @@ public class XslFoDocumentBuilder {
 		document.addContent(e);
 	}
 	
-	public void addPageMaster(String name, float widthMM, float heightMM) {
+	public void addPageMaster(String name, int widthPX, int heightPX) {
 		Element m = new Element("simple-page-master", ns);
 		m.setAttribute("master-name", name);
-		m.setAttribute("page-width", widthMM + "mm");
-		m.setAttribute("page-height", heightMM + "mm");
-		m.setAttribute("margin", "0mm");
+		m.setAttribute("page-width", widthPX + "px");
+		m.setAttribute("page-height", heightPX + "px");
+		m.setAttribute("margin", "0px");
 		
 		Element body = new Element("region-body", ns);
 		m.addContent(body);
@@ -80,9 +80,9 @@ public class XslFoDocumentBuilder {
 		
 		Element e = new Element("block", ns);
 		e.setAttribute("break-after", "page");
-		e.setAttribute("padding", "0mm");
-		e.setAttribute("margin", "0mm");
-		e.setAttribute("border-width", "0mm");
+		e.setAttribute("padding", "0px");
+		e.setAttribute("margin", "0px");
+		e.setAttribute("border-width", "0px");
 		flow.addContent(e);
 	}
 	
@@ -94,23 +94,23 @@ public class XslFoDocumentBuilder {
 		return ns;
 	}
 
-	public void addPageElement(Element element, float widthMM, float heightMM) {
+	public void addPageElement(Element element, int widthPX, int heightPX) {
 		if (flow == null)
 			throw new IllegalStateException("Please call startFlow() first");
 		
 		// create block container
 		Element bc = new Element("block-container",ns);
 		bc.setAttribute("absolute-position", "absolute");
-		bc.setAttribute("left", "0mm");
-		bc.setAttribute("top", "0mm");
-		bc.setAttribute("width", widthMM + "mm");
-		bc.setAttribute("height", heightMM + "mm");
+		bc.setAttribute("left", "0px");
+		bc.setAttribute("top", "0px");
+		bc.setAttribute("width", widthPX + "px");
+		bc.setAttribute("height", heightPX + "px");
 		
 		// create block
 		Element b = new Element("block", ns);
-		b.setAttribute("margin", "0mm");
-		b.setAttribute("padding", "0mm");
-		b.setAttribute("border-width", "0mm");
+		b.setAttribute("margin", "0px");
+		b.setAttribute("padding", "0px");
+		b.setAttribute("border-width", "0px");
 		bc.addContent(b);
 		
 		b.addContent(element);

--- a/src/main/java/net/sf/mcf2pdf/mcfelements/util/XslFoDocumentBuilder.java
+++ b/src/main/java/net/sf/mcf2pdf/mcfelements/util/XslFoDocumentBuilder.java
@@ -41,7 +41,6 @@ public class XslFoDocumentBuilder {
 		m.setAttribute("master-name", name);
 		m.setAttribute("page-width", widthPX + "px");
 		m.setAttribute("page-height", heightPX + "px");
-		m.setAttribute("margin", "0px");
 		
 		Element body = new Element("region-body", ns);
 		m.addContent(body);
@@ -62,7 +61,6 @@ public class XslFoDocumentBuilder {
 		
 		Element ps = new Element("page-sequence", ns);
 		ps.setAttribute("master-reference", masterName);
-		ps.setAttribute("id", masterName);
 		Element f = new Element("flow", ns);
 		f.setAttribute("flow-name", "xsl-region-body");
 		ps.addContent(f);
@@ -94,28 +92,18 @@ public class XslFoDocumentBuilder {
 		return ns;
 	}
 
-	public void addPageElement(Element element, int widthPX, int heightPX) {
+	public void addPageElement(String imgSource) {
 		if (flow == null)
 			throw new IllegalStateException("Please call startFlow() first");
 		
 		// create block container
 		Element bc = new Element("block-container",ns);
-		bc.setAttribute("absolute-position", "absolute");
-		bc.setAttribute("left", "0px");
-		bc.setAttribute("top", "0px");
-		bc.setAttribute("width", widthPX + "px");
-		bc.setAttribute("height", heightPX + "px");
-		
-		// create block
-		Element b = new Element("block", ns);
-		b.setAttribute("margin", "0px");
-		b.setAttribute("padding", "0px");
-		b.setAttribute("border-width", "0px");
-		bc.addContent(b);
-		
-		b.addContent(element);
+		bc.setAttribute("background-image", imgSource);
+		bc.setAttribute("width", "100%");
+		bc.setAttribute("height", "100%");
+		bc.addContent(new Element("block", ns));
 		
 		flow.addContent(bc);
-	}	
+	}
 
 }

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/BitmapPageBuilder.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/BitmapPageBuilder.java
@@ -23,7 +23,6 @@ import javax.imageio.ImageIO;
 
 import net.sf.mcf2pdf.mcfelements.util.XslFoDocumentBuilder;
 
-import org.jdom.Element;
 import org.jdom.Namespace;
 
 
@@ -83,11 +82,11 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 			}
 		}
 
-		docBuilder.addPageElement(createXslFoElement(img, docBuilder.getNamespace()), widthPX, heightPX);
+		docBuilder.addPageElement(createImgFoElement(img, docBuilder.getNamespace()));
 		g2d.dispose();
 	}
 
-	private Element createXslFoElement(BufferedImage img, Namespace xslFoNs) throws IOException {
+	private String createImgFoElement(BufferedImage img, Namespace xslFoNs) throws IOException {
 		// save bitmap to file
 		File f;
 		int i = 1;
@@ -102,14 +101,10 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 		g2d.dispose();
 
 		ImageIO.write(imgPlain, "jpeg", f);
-
-		Element eg = new Element("external-graphic", xslFoNs);
-		eg.setAttribute("src", f.getAbsolutePath());
-		eg.setAttribute("content-width", widthPX + "px");
-		eg.setAttribute("content-height", heightPX + "px");
+		String src = f.getAbsolutePath();
 		f.deleteOnExit();
 
-		return eg;
+		return src;
 	}
 
 

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/BitmapPageBuilder.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/BitmapPageBuilder.java
@@ -34,9 +34,9 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 
 	private PageRenderContext context;
 
-	private float widthMM;
+	private int widthPX;
 
-	private float heightMM;
+	private int heightPX;
 
 	private static final Comparator<PageDrawable> zComp = new Comparator<PageDrawable>() {
 		@Override
@@ -45,10 +45,10 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 		}
 	};
 
-	public BitmapPageBuilder(float widthMM, float heightMM,
+	public BitmapPageBuilder(int widthPX, int heightPX,
 			PageRenderContext context, File tempImageDir) throws IOException {
-		this.widthMM = widthMM;
-		this.heightMM = heightMM;
+		this.widthPX = widthPX;
+		this.heightPX = heightPX;
 		this.context = context;
 		this.tempImageDir = tempImageDir;
 	}
@@ -62,8 +62,7 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 
 		context.getLog().debug("Creating full page image from page elements");
 
-		BufferedImage img = new BufferedImage(context.toPixel(widthMM),
-				context.toPixel(heightMM), BufferedImage.TYPE_INT_ARGB);
+		BufferedImage img = new BufferedImage(widthPX, heightPX, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2d = img.createGraphics();
 		g2d.setColor(Color.white);
 		g2d.fillRect(0, 0, img.getWidth(), img.getHeight());
@@ -74,7 +73,7 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 
 			Point offset = new Point();
 			try {
-				BufferedImage pdImg = pd.renderAsBitmap(context, offset);
+				BufferedImage pdImg = pd.renderAsBitmap(context, offset, widthPX, heightPX);
 				if (pdImg != null)
 					g2d.drawImage(pdImg, left + offset.x, top + offset.y, null);
 			}
@@ -84,7 +83,7 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 			}
 		}
 
-		docBuilder.addPageElement(createXslFoElement(img, docBuilder.getNamespace()), widthMM, heightMM);
+		docBuilder.addPageElement(createXslFoElement(img, docBuilder.getNamespace()), widthPX, heightPX);
 		g2d.dispose();
 	}
 
@@ -106,8 +105,8 @@ public class BitmapPageBuilder extends AbstractPageBuilder {
 
 		Element eg = new Element("external-graphic", xslFoNs);
 		eg.setAttribute("src", f.getAbsolutePath());
-		eg.setAttribute("content-width", widthMM + "mm");
-		eg.setAttribute("content-height", heightMM + "mm");
+		eg.setAttribute("content-width", widthPX + "px");
+		eg.setAttribute("content-height", heightPX + "px");
 		f.deleteOnExit();
 
 		return eg;

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageBackground.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageBackground.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import net.sf.mcf2pdf.mcfelements.McfBackground;
 import net.sf.mcf2pdf.mcfelements.util.ImageUtil;
-import net.sf.mcf2pdf.mcfglobals.McfAlbumType;
 
 
 public class PageBackground implements PageDrawable {

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageBackground.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageBackground.java
@@ -41,17 +41,11 @@ public class PageBackground implements PageDrawable {
 
 	@Override
 	public BufferedImage renderAsBitmap(PageRenderContext context,
-			Point drawOffsetPixels) throws IOException {
+			Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
 		File fLeft = extractBackground(leftBg, context);
 		File fRight = extractBackground(rightBg, context);
 
-		McfAlbumType albumType = context.getAlbumType();
-
-		float widthMM = (albumType.getUsableWidth() + albumType.getBleedMargin()) / 10.0f * 2;
-		float heightMM = (albumType.getUsableHeight() + albumType.getBleedMargin() * 2) / 10.0f;
-
-		BufferedImage img = new BufferedImage(context.toPixel(widthMM),
-				context.toPixel(heightMM), BufferedImage.TYPE_INT_ARGB);
+		BufferedImage img = new BufferedImage(widthPX, heightPX, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2d = img.createGraphics();
 		g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageBinding.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageBinding.java
@@ -17,14 +17,8 @@ public class PageBinding implements PageDrawable {
 
 	private BufferedImage bindingImg;
 
-	private float pageWidthMM;
-
-	private float pageHeightMM;
-
-	public PageBinding(File fBindingImg, float pageWidthMM, float pageHeightMM) throws IOException {
+	public PageBinding(File fBindingImg) throws IOException {
 		bindingImg = ImageUtil.readImage(fBindingImg);
-		this.pageWidthMM = pageWidthMM;
-		this.pageHeightMM = pageHeightMM;
 	}
 
 	@Override
@@ -33,27 +27,25 @@ public class PageBinding implements PageDrawable {
 	}
 
 	@Override
-	public void renderAsSvgElement(Writer writer,	PageRenderContext context) throws IOException {
+	public void renderAsSvgElement(Writer writer, PageRenderContext context) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public BufferedImage renderAsBitmap(PageRenderContext context,
-			Point drawOffsetPixels) throws IOException {
+			Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
 		context.getLog().debug("Rendering page binding");
-		float widthMM = pageWidthMM / 16.0f;
+		
+		int width = Math.round(widthPX / 16.0f);
 
-		int width = context.toPixel(widthMM);
-		int height = context.toPixel(pageHeightMM);
-
-		BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage img = new BufferedImage(width, heightPX, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2d = img.createGraphics();
 		g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
 
-		g2d.drawImage(bindingImg, 0, 0, width, height, 0, 0, bindingImg.getWidth(), bindingImg.getHeight(), null);
+		g2d.drawImage(bindingImg, 0, 0, width, heightPX, 0, 0, bindingImg.getWidth(), bindingImg.getHeight(), null);
 		g2d.dispose();
 
-		drawOffsetPixels.x = context.toPixel((pageWidthMM - widthMM) / 2.0f);
+		drawOffsetPixels.x = Math.round((widthPX - width) / 2.0f);
 		drawOffsetPixels.y = 0;
 
 		return img;

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageClipart.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageClipart.java
@@ -47,7 +47,7 @@ public class PageClipart implements PageDrawable {
 
 	@Override
 	public BufferedImage renderAsBitmap(PageRenderContext context,
-			Point drawOffsetPixels) throws IOException {
+			Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
 		File f = context.getClipart(clipart.getUniqueName());
 		if (f == null) {
 			context.getLog().warn("Clipart not found: " + clipart.getUniqueName());

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageDrawable.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageDrawable.java
@@ -60,7 +60,7 @@ public interface PageDrawable {
 	 * @throws IOException If any I/O related problem occurs, e.g. reading an
 	 * image file.
 	 */
-	public BufferedImage renderAsBitmap(PageRenderContext context, Point drawOffsetPixels) throws IOException;
+	public BufferedImage renderAsBitmap(PageRenderContext context, Point drawOffsetPixels, int widthPX, int heightPX) throws IOException;
 	
 	/**
 	 * Returns the Z position of this drawable. This is mostly indicated by the

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageImage.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageImage.java
@@ -59,7 +59,7 @@ public class PageImage implements PageDrawable {
 	}
 
 	@Override
-	public BufferedImage renderAsBitmap(PageRenderContext context, Point drawOffsetPixels) throws IOException {
+	public BufferedImage renderAsBitmap(PageRenderContext context, Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
 		int widthPixel = context.toPixel(image.getArea().getWidth() / 10.0f);
 		int heightPixel = context.toPixel(image.getArea().getHeight() / 10.0f);
 		if (image.getFileName() == null || "".equals(image.getFileName())) {

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageImageBackground.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageImageBackground.java
@@ -25,8 +25,8 @@ public class PageImageBackground extends PageImage {
 	
 	@Override
 	public BufferedImage renderAsBitmap(PageRenderContext context,
-			Point drawOffsetPixels) throws IOException {
-		BufferedImage img = super.renderAsBitmap(context, drawOffsetPixels);
+			Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
+		BufferedImage img = super.renderAsBitmap(context, drawOffsetPixels, widthPX, heightPX);
 		if (McfImageBackground.RIGHT_OR_BOTTOM.equals(image.getBackgroundPosition())) {
 			McfAlbumType albumType = context.getAlbumType();
 			drawOffsetPixels.x += context.toPixel(albumType.getUsableWidth() / 10.0f + 

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageText.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageText.java
@@ -162,7 +162,7 @@ public class PageText implements PageDrawable {
 
 	@Override
 	public BufferedImage renderAsBitmap(PageRenderContext context,
-			Point drawOffsetPixels) throws IOException {
+			Point drawOffsetPixels, int widthPX, int heightPX) throws IOException {
 		context.getLog().debug("Rendering text");
 		int width = context.toPixel(text.getArea().getWidth() / 10.0f);
 		int height = context.toPixel(text.getArea().getHeight() / 10.0f);


### PR DESCRIPTION
* Fixed support for spine
* Fixed background-size for cover (error due to missing spine)
* Bugfix: sometimes white border at top of page
* Improved generated XSL-FO, also a speed improvement, due to rendering img as background-image
* Added support for xml->bundlesize attribute to get coverWidth (which includes spineWidth)
* Removed unused imports

Should also fix: #15

Note: `the bundlesize attribute might not be backwarts compatible!` I coun`t check that.