### PR TITLE
Fixed issue - rendering of bold fonts

### DIFF
--- a/src/main/java/net/sf/mcf2pdf/Main.java
+++ b/src/main/java/net/sf/mcf2pdf/Main.java
@@ -50,6 +50,7 @@ public class Main {
 		options.addOption("r", true, "Sets the resolution to use for page rendering, in DPI. Default is 150.");
 		options.addOption("n", true, "Sets the page number to render up to. Default renders all pages.");
 		options.addOption("b", false, "Prevents rendering of binding between double pages.");
+		options.addOption("s", true, "Set scaling for fonts which don't support bold text nativly. Default is 0.82.");
 		options.addOption("x", false, "Generates only XSL-FO content instead of PDF content.");
 		options.addOption("q", false, "Quiet mode - only errors are logged.");
 		options.addOption("d", false, "Enables debugging logging output.");
@@ -148,6 +149,15 @@ public class Main {
 		if (cl.hasOption("b")) {
 			binding = false;
 		}
+		
+		double sx = 0.82d;
+		if (cl.hasOption("s")) {
+			try {
+				sx = Double.valueOf(cl.getOptionValue("s")).doubleValue();
+			} catch (Exception e) {
+				printUsage(options, new ParseException("Parameter for option -s must be a double value."));
+			}
+		}
 
 		OutputStream finalOut;
 		if (cl.getArgs()[1].equals("-"))
@@ -186,7 +196,7 @@ public class Main {
 
 		try {
 			new Mcf2FoConverter(installDir, tempDir, tempImages).convert(
-					mcfFile, xslFoOut, dpi, binding, maxPageNo);
+					mcfFile, xslFoOut, dpi, binding, maxPageNo, sx);
 			xslFoOut.flush();
 
 			if (!cl.hasOption("x")) {

--- a/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
+++ b/src/main/java/net/sf/mcf2pdf/Mcf2FoConverter.java
@@ -148,7 +148,7 @@ public class Mcf2FoConverter {
 	 * @throws SAXException If any XML related problem occurs, e.g. the input file
 	 * has an invalid format.
 	 */
-	public void convert(File mcfFile, OutputStream xslFoOut, int dpi, boolean binding, int maxPageNo) throws IOException, SAXException {
+	public void convert(File mcfFile, OutputStream xslFoOut, int dpi, boolean binding, int maxPageNo, double sx) throws IOException, SAXException {
 		// build MCF DOM
 		log.debug("Reading MCF file");
 		McfFotobook book = new FotobookBuilder().readFotobook(mcfFile);
@@ -170,7 +170,7 @@ public class Mcf2FoConverter {
 			throw new IOException("No album type definition found for used print product '" + book.getProductName() + "'");
 
 		// prepare page render context
-		context = new PageRenderContext(dpi, resources, albumType);
+		context = new PageRenderContext(dpi, sx, resources, albumType);
 
 		// create XSL-FO document
 		XslFoDocumentBuilder docBuilder = new XslFoDocumentBuilder();

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/FormattedTextParagraph.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/FormattedTextParagraph.java
@@ -8,6 +8,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.font.TextAttribute;
+import java.awt.geom.AffineTransform;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 import java.util.Collections;
@@ -85,7 +86,13 @@ public class FormattedTextParagraph {
 			float fontSizeInch = text.getFontSize() / 72.0f;
 			
 			map.put(TextAttribute.SIZE, fontSizeInch * context.getTargetDpi());
+			Font fontOriginal = font;
 			font = font.deriveFont(map);
+			if (map.get(TextAttribute.WEIGHT) == TextAttribute.WEIGHT_BOLD && font.getFontName().equals(fontOriginal.getFontName())) {
+				AffineTransform afT = new AffineTransform();
+				afT.setToScale(context.getSX(), 1);
+				font = font.deriveFont(afT);
+			}
 			map.put(TextAttribute.FONT, font);
 
 			if (text.getText().length() > 0) {

--- a/src/main/java/net/sf/mcf2pdf/pagebuild/PageRenderContext.java
+++ b/src/main/java/net/sf/mcf2pdf/pagebuild/PageRenderContext.java
@@ -27,6 +27,8 @@ import net.sf.mcf2pdf.mcfglobals.McfResourceScanner;
 public final class PageRenderContext {
 
 	private final static Log log = LogFactory.getLog(PageRenderContext.class);
+	
+	private double sx;
 
 	private int targetDpi;
 
@@ -34,9 +36,10 @@ public final class PageRenderContext {
 
 	private McfAlbumType albumType;
 
-	public PageRenderContext(int targetDpi, McfResourceScanner resources,
+	public PageRenderContext(int targetDpi, double sx, McfResourceScanner resources,
 			McfAlbumType albumType) {
 		this.targetDpi = targetDpi;
+		this.sx = sx;
 		this.resources = resources;
 		this.albumType = albumType;
 	}
@@ -48,6 +51,15 @@ public final class PageRenderContext {
 	 */
 	public Log getLog() {
 		return log;
+	}
+	
+	/**
+	 * Returns the scaling factor for fonts that don't natively support bold text.
+	 * 
+	 * @return the scaling factor for fonts that don't natively support bold text.
+	 */
+	public double getSX() {
+		return sx;
 	}
 
 	/**


### PR DESCRIPTION
In some cases bold fonts weren't rendered correctly. Especially for fonts that don't natively support bold text. See image below. For this demonstration I used the [Tangerine Font](https://fonts.google.com/specimen/Tangerine) from Google but it's not the only font that has the issue. Normally both lines should be the same length.
![bug_bold-fonts](https://user-images.githubusercontent.com/30130371/34483946-de871c1a-efc1-11e7-8624-2569f9141c50.jpg)

I solved the issue by adding a scaling transformation to those fonts that don't support bold text. Due to the fact that all fonts are slightly diffrent, I added the option `s` to allow the user to set an individual scaling factor for their font.
![fix_bold-fonts](https://user-images.githubusercontent.com/30130371/34483997-3742c1f6-efc2-11e7-8a0e-7130b276fe8f.jpg)